### PR TITLE
Docker Network Setup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,9 +6,9 @@ Vagrant.configure("2") do |config|
 
   # Network configuration
   config.vm.network "private_network", ip: "192.168.56.10"
-  config.vm.network "forwarded_port", guest: 3000, host: 3000, auto_correct: true
-  config.vm.network "forwarded_port", guest: 5000, host: 5000, auto_correct: true
-  config.vm.network "forwarded_port", guest: 27017, host: 27017, auto_correct: true
+  config.vm.network "forwarded_port", guest: 3000, host: 3001, auto_correct: true
+  config.vm.network "forwarded_port", guest: 5000, host: 5001, auto_correct: true
+  config.vm.network "forwarded_port", guest: 27017, host: 27018, auto_correct: true
   
   # VM resource allocation
   config.vm.provider "virtualbox" do |vb|

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,24 +1,24 @@
 
 app_name: yolo-ecommerce
 repo_url: https://github.com/Sophie-Muchiri12/yolo.git
-app_directory: ~/DevOps-Course/yolo
+app_directory: /home/vagrant/yolo
 app_user: vagrant
 
 # Docker configuration
 docker_compose_version: "1.29.2"
 
 # Database configuration
-mongodb_container_name: yolo_db
+mongodb_container_name: yolo-mongodb
 mongodb_port: 27017
-mongodb_data_path: ~/DevOps-Course/yolo/mongo-init.js
+mongodb_data_path: /home/vagrant/yolo/mongo-init.js
 
 # Backend configuration
-backend_container_name: backend-final
+backend_container_name: yolo-backend
 backend_port: 5000
 backend_image: backend-final
 
 # Frontend configuration
-frontend_container_name: clients-app
+frontend_container_name: yolo-frontend
 frontend_port: 3000
 frontend_image: client-final
 

--- a/playbook.yml
+++ b/playbook.yml
@@ -32,7 +32,7 @@
       tags: ['always']
 
     - name: Verify all containers are running
-      command: docker ps --format "table {{.Names}}\t{{.Status}}"
+      shell: docker ps --format "table {{ '{{.Names}}' }}\t{{ '{{.Status}}' }}"
       register: container_status
       
     - name: Show container status

--- a/roles/backend/tasks/main.yml
+++ b/roles/backend/tasks/main.yml
@@ -33,6 +33,8 @@
         image: "{{ backend_image }}:latest"
         state: started
         restart_policy: always
+        networks:
+          - name: yolo_yolo-network
         ports:
           - "{{ backend_port }}:5000"
         

--- a/roles/database/tasks/main.yml
+++ b/roles/database/tasks/main.yml
@@ -1,65 +1,16 @@
+- name: Create Docker network
+  docker_network:
+    name: yolo_yolo-network
+    state: present
 
 
-- name: Docker installation and configuration
-  block:
-    - name: Add Docker GPG key
-      apt_key:
-        url: https://download.docker.com/linux/ubuntu/gpg
-        state: present
-      tags: ['docker-install']
-
-    - name: Add Docker repository
-      apt_repository:
-        repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
-        state: present
-      tags: ['docker-install']
-
-    - name: Install Docker packages
-      apt:
-        name:
-          - docker-ce
-          - docker-ce-cli
-          - containerd.io
-        state: present
-        update_cache: yes
-      tags: ['docker-install']
-
-    - name: Start and enable Docker service
-      systemd:
-        name: docker
-        state: started
-        enabled: yes
-      tags: ['docker-service']
-
-    - name: Add user to docker group
-      user:
-        name: "{{ app_user }}"
-        groups: docker
-        append: yes
-      tags: ['docker-permissions']
-
-    - name: Install Docker Compose
-      get_url:
-        url: "https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-Linux-x86_64"
-        dest: /usr/local/bin/docker-compose
-        mode: '0755'
-      tags: ['docker-compose']
-
-    - name: Install Python Docker library
-      pip:
-        name:
-          - docker
-          - docker-compose
-        state: present
-      tags: ['docker-python']
-
-    - name: Create Docker network
-      docker_network:
-        name: "{{ docker_network_name }}"
-        state: present
-      tags: ['docker-network']
-
-  rescue:
-    - name: Handle Docker installation errors
-      debug:
-        msg: "Error installing Docker: {{ ansible_failed_result.msg }}"
+- name: Run MongoDB container
+  docker_container:
+    name: yolo-mongodb
+    image: mongo:latest
+    state: started
+    restart_policy: always
+    ports:
+      - "27017:27017"
+    networks:
+      - name: yolo_yolo-network

--- a/roles/frontend/tasks/main.yml
+++ b/roles/frontend/tasks/main.yml
@@ -33,6 +33,8 @@
         image: "{{ frontend_image }}:latest"
         state: started
         restart_policy: always
+        networks:
+          - name: yolo_yolo-network
         ports:
           - "{{ frontend_port }}:3000"
         


### PR DESCRIPTION
Corrected Ansible roles to explicitly create and use a named Docker network (yolo_yolo-network) for all containers.

Ensured backend and frontend services are correctly connected to this network to avoid "not attached to default bridge network" errors.